### PR TITLE
Wifi: Create new module for wifi connectivity.

### DIFF
--- a/src/system/connectivity/wifi.cpp
+++ b/src/system/connectivity/wifi.cpp
@@ -1,0 +1,16 @@
+#include "wifi.h"
+
+/**
+ * @brief Initialize WIFI interface using the specified configuration.
+ * 
+ * @param wifi_ssid      [Optional] WiFi SSID as a const char string.
+ * @param wifi_password  [Optional] WiFi Password as a const char string.
+ * @return wl_status_t   WiFi status code.
+ */
+wl_status_t WifiInitialize (
+    const char* wifi_ssid,
+    const char* wifi_password
+    )
+{
+    return WL_CONNECTED;
+}

--- a/src/system/connectivity/wifi.h
+++ b/src/system/connectivity/wifi.h
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------*
+ *  _   __ _     _____ _____                                            *
+ * | | / /| |   |_   _/  __ \   This software is been developed by      *
+ * | |/ / | |     | | | /  \/   a group of enthusiast hobbiest          *
+ * |    \ | |     | | | |       with the purpose of learn and           *
+ * | |\  \| |_____| |_| \__/\   have fun, so nobody is responsible or   *
+ * \_| \_/\_____/\___/ \____/   will provide warranty.                  *
+ *                                                                      *
+ * This software will run in a ESP8266 microcontrolller, the objective  *
+ * is to have a irrigation system controler that can read some sensors  *
+ * and decide if a valve should be open.                                *
+ * There is not restriction to use, modify and improve the code, so     *
+ * please do it and share the improvements.                             *
+ *                                                                      *
+ * Letś have Fun!!                                                      *
+ *                                                                      *
+ * ---------------------------------------------------------------------*/
+
+#if !defined(__IRRIGATION_SYSTEM_CONNECTIVITY_WIFI_H__)
+#define __IRRIGATION_SYSTEM_CONNECTIVITY_WIFI_H__
+
+#include <ESP8266WiFi.h>
+
+/**
+ * @brief Specifies the wifi ssid.
+ * 
+ */
+extern const char* WIFI_SSID;
+
+/**
+ * @brief Specifies the wifi password.
+ * 
+ */
+extern const char* WIFI_PASSWORD;
+
+/**
+ * @brief Initialize WIFI interface using the specified configuration.
+ * 
+ * @param wifi_ssid      [Optional] WiFi SSID as a const char string.
+ * @param wifi_password  [Optional] WiFi Password as a const char string.
+ * @return wl_status_t   WiFi status code.
+ */
+wl_status_t WifiInitialize (
+    const char* wifi_ssid = WIFI_SSID,
+    const char* wifi_password = WIFI_PASSWORD
+    );
+
+#endif // !__IRRIGATION_SYSTEM_CONNECTIVITY_WIFI_H__

--- a/src/system/time/services/ntp.cpp
+++ b/src/system/time/services/ntp.cpp
@@ -4,9 +4,6 @@
 #define NTP_INTERVAL 60 * 1000       // miliseconds
 #define NTP_ADDRESS  "pool.ntp.org"  // URL NTP Server
 
-extern const char* NTP_WIFI_SSID;
-extern const char* NTP_WIFI_PASSWORD;
-
 /**
  * @brief Initialize the time provider.
  * 

--- a/src/user_config.cpp
+++ b/src/user_config.cpp
@@ -1,2 +1,2 @@
-const char* NTP_WIFI_SSID = "xxxxxxxxx";    // change for your ssid 
-const char* NTP_WIFI_PASSWORD = "xxxxxxxx"; // Add your password
+const char* WIFI_SSID = "xxxxxxxxx";    // change for your ssid 
+const char* WIFI_PASSWORD = "xxxxxxxx"; // Add your password


### PR DESCRIPTION
This change was suggested due that the wifi functionality was included
inside the ntp module, so now the wifi have their own module to be
initialized.

Signed-off-by: Juan D Polanco Avalos <juan.polanco.avalos@intel.com>