### PR TITLE
Fix CI build error due to header name

### DIFF
--- a/src/system/bus/i2c/i2cDevice.cpp
+++ b/src/system/bus/i2c/i2cDevice.cpp
@@ -1,4 +1,4 @@
-#include "I2CDevice.h"
+#include "i2cDevice.h"
 #include <Arduino.h>
 #include <stdint.h>
 

--- a/src/system/relays/io_expander.h
+++ b/src/system/relays/io_expander.h
@@ -19,7 +19,7 @@
 #define __IRRIGATION_SYSTEM_RELAYS_IO_EXPANDER_H__
 #define PCA9554_OUTPUT_REG1 1
 #define PCA9554_CONFIG_REG3 3
-#include "system/bus/i2c/I2CDevice.h"
+#include "system/bus/i2c/i2cDevice.h"
 #include <stdint.h>
 
 /**


### PR DESCRIPTION
On Linux (CI image) the path is case sensitive, so fix the include header name

Signed-off-by: Polanco Avalos, Juan <juan.polanco.avalos@intel.com>