### PR TITLE
Generate dinamically the version tag

### DIFF
--- a/git_rev_macro.py
+++ b/git_rev_macro.py
@@ -1,0 +1,15 @@
+import subprocess
+
+try:
+    revision = (
+        subprocess.check_output(["git", "describe", "--tags"])
+        .strip()
+        .decode("utf-8")
+    )
+    dirty = subprocess.check_output(['git', 'diff', '--stat']).strip().__len__() > 0
+
+    version = f'"{revision}{"-d" if dirty else ""}"'
+except:
+    version = '"UNKNOWN"'
+
+print("'-DFIRMWARE_VERSION=%s'" % version)

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,5 +22,7 @@ lib_deps =
 	adafruit/RTClib@^2.1.1
 	SPI
 build_flags =
-	-D DEBUG_NTPClient
-	-D LOG_LEVEL=LOG_DEBUG
+	!python git_rev_macro.py
+	-DLOG_LEVEL=LOG_DEBUG
+
+debug_build_flags = -DDEBUG_NTPClient

--- a/src/system/irrigation.cpp
+++ b/src/system/irrigation.cpp
@@ -78,7 +78,7 @@ void IrrigationSystem::DumpSysInfo()
            << "           | |\\  \\| |_____| |_| \\__/\\      \n"
            << "           \\_| \\_/\\_____/\\___/ \\____/     \n"
            << "--------------------------------------------------------\n"
-           << LOG_MASTER << "Fimware version: " << KERNEL_VERSION << EndLine
+           << LOG_MASTER << "Fimware version: " << FIRMWARE_VERSION << EndLine
            << LOG_MASTER << "Build date: " << Time_s(getBuildTime(__DATE__, __TIME__)).toString() << EndLine;
 }
 

--- a/src/system/irrigation.h
+++ b/src/system/irrigation.h
@@ -28,7 +28,6 @@
 #include "utils/logger.h"
 #include "system/connectivity/wifi.h"
 
-#define KERNEL_VERSION "0.3.1"
 #define KERNEL_SERIAL_SPEED 115200
 
 class SystemTimeProvider : public ITimeProvider {


### PR DESCRIPTION
Use a python script to generate the firmware version dynamically from the git tags

Output example.
![image](https://user-images.githubusercontent.com/33843865/224045110-d16ffd72-87a3-405d-9fd0-fb9fd07bf583.png)
