### PR TITLE
Do not loop through all the time providers, 

### DIFF
--- a/src/system/time/controller.hpp
+++ b/src/system/time/controller.hpp
@@ -74,6 +74,9 @@ private:
         if (now <= d) {
           now = d;
         }
+        if (_tp->getType() == PRIMARY) {
+          return now;
+        }
       } else {
         logger << LOG_ERROR << "Error while updating time provider!" << EndLine;
       }


### PR DESCRIPTION
if the PRIMARY is successful, then just update the BACKUPs
this fix the issue of only taking the RTC and not updating it with the information obtained fron the NTP